### PR TITLE
Merge release v1.0.3 into staging branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.2] - 2020-08-11
 
 [Unreleased]: https://github.com/rosslh/ReqWise/compare/v1.0.3...HEAD
-
 [v1.0.3]: https://github.com/rosslh/ReqWise/compare/v1.0.2...v1.0.3
-
 [v1.0.2]: https://github.com/rosslh/ReqWise/compare/v1.0.1...v1.0.2
-
 [v1.0.1]: https://github.com/rosslh/ReqWise/compare/v1.0.0...v1.0.1
-
 [v1.0.0]: https://github.com/rosslh/ReqWise/compare/35e4d056bf35102a97fb568dd201139e491ea14c...v1.0.0


### PR DESCRIPTION
This PR merges the release branch for v1.0.3 back into staging.
This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG updates are also present on the staging branch.